### PR TITLE
Identity context

### DIFF
--- a/dispatch.go
+++ b/dispatch.go
@@ -10,7 +10,7 @@ func (d dispatch) Serve(in Invocation) (interface{}, error) {
 	handler, found := d.repository.resolvers[in.Resolve]
 
 	if found {
-		return handler.call(in.payload())
+		return handler.call(in.payload(), in.identity())
 	}
 
 	return nil, fmt.Errorf("No resolver found: %s", in.Resolve)

--- a/go.mod
+++ b/go.mod
@@ -14,3 +14,5 @@ require (
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v2 v2.2.1 // indirect
 )
+
+go 1.13

--- a/invocation.go
+++ b/invocation.go
@@ -4,8 +4,9 @@ import "encoding/json"
 
 // ContextData data received from AppSync
 type ContextData struct {
-	Arguments json.RawMessage `json:"arguments"`
-	Source    json.RawMessage `json:"source"`
+	Arguments json.RawMessage  `json:"arguments"`
+	Source    json.RawMessage  `json:"source"`
+	Identity  *json.RawMessage `json:"identity"`
 }
 
 // Invocation data received from AppSync
@@ -24,4 +25,8 @@ func (in Invocation) payload() json.RawMessage {
 	}
 
 	return in.Context.Source
+}
+
+func (in Invocation) identity() *json.RawMessage {
+	return in.Context.Identity
 }

--- a/payload.go
+++ b/payload.go
@@ -10,12 +10,13 @@ type payload struct {
 	Message json.RawMessage
 }
 
-func (p payload) parse(argsType reflect.Type) ([]reflect.Value, error) {
+func (p payload) parse(argsType reflect.Type) (*reflect.Value, error) {
 	args := reflect.New(argsType)
 
 	if err := json.Unmarshal(p.Message, args.Interface()); err != nil {
 		return nil, fmt.Errorf("Unable to prepare payload: %s", err.Error())
 	}
 
-	return append([]reflect.Value{}, args.Elem()), nil
+	e := args.Elem()
+	return &e, nil
 }

--- a/payload_test.go
+++ b/payload_test.go
@@ -42,13 +42,12 @@ var _ = Describe("Payload", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("should return struct", func() {
+		It("should return data", func() {
 			Expect(args).NotTo(BeNil())
 		})
 
 		It("should parse data", func() {
-			Expect(args).To(HaveLen(1))
-			Expect(args[0].FieldByName("Name").String()).To(Equal("example"))
+			Expect(args.FieldByName("Name").String()).To(Equal("example"))
 		})
 	})
 })

--- a/repository_test.go
+++ b/repository_test.go
@@ -12,13 +12,17 @@ var _ = Describe("Repository", func() {
 	type arguments struct {
 		Bar string `json:"bar"`
 	}
+	type identity struct {
+		Bar string `json:"bar"`
+	}
 	type response struct {
 		Foo string
 	}
 	r := New()
 	r.Add("example.resolver", func(arg arguments) (response, error) { return response{"bar"}, nil })
 	r.Add("example.resolver.with.error", func(arg arguments) (response, error) { return response{"bar"}, errors.New("Has Error") })
-
+	r.Add("example.resolver.with.identity", func(arg arguments, ident identity) (response, error) { return response{"foo"}, nil })
+	r.Add("example.resolver.with.identity.with.error", func(arg arguments, ident identity) (response, error) { return response{"foo"}, errors.New("Has Error") })
 	Context("Matching invocation", func() {
 		res, err := r.Handle(Invocation{
 			Resolve: "example.resolver",
@@ -36,11 +40,45 @@ var _ = Describe("Repository", func() {
 		})
 	})
 
+	Context("Matching invocation with identity", func() {
+		identityMessage := json.RawMessage(`{"bar":"foo"}`)
+		res, err := r.Handle(Invocation{
+			Resolve: "example.resolver.with.identity",
+			Context: ContextData{
+				Arguments: json.RawMessage(`{"bar":"foo"}`),
+				Identity:  &identityMessage,
+			},
+		})
+
+		It("Should not error", func() {
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Should have data", func() {
+			Expect(res.(response).Foo).To(Equal("foo"))
+		})
+	})
+
 	Context("Matching invocation with error", func() {
 		_, err := r.Handle(Invocation{
 			Resolve: "example.resolver.with.error",
 			Context: ContextData{
 				Arguments: json.RawMessage(`{"bar":"foo"}`),
+			},
+		})
+
+		It("Should error", func() {
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Context("Matching invocation with identity and error", func() {
+		identityMessage := json.RawMessage(`{"bar:foo"}`)
+		_, err := r.Handle(Invocation{
+			Resolve: "example.resolver.with.identity.with.error",
+			Context: ContextData{
+				Arguments: json.RawMessage(`{"bar":"foo"}`),
+				Identity:  &identityMessage,
 			},
 		})
 

--- a/resolver.go
+++ b/resolver.go
@@ -10,20 +10,33 @@ type resolver struct {
 }
 
 func (r *resolver) hasArguments() bool {
-	return reflect.TypeOf(r.function).NumIn() == 1
+	return reflect.TypeOf(r.function).NumIn() >= 1
+}
+func (r *resolver) hasIdentity() bool {
+	return reflect.TypeOf(r.function).NumIn() >= 2
 }
 
-func (r *resolver) call(p json.RawMessage) (interface{}, error) {
+func (r *resolver) call(p json.RawMessage, i *json.RawMessage) (interface{}, error) {
 	var args []reflect.Value
-	var err error
 
 	if r.hasArguments() {
 		pld := payload{p}
-		args, err = pld.parse(reflect.TypeOf(r.function).In(0))
+		arguments, err := pld.parse(reflect.TypeOf(r.function).In(0))
 
 		if err != nil {
 			return nil, err
 		}
+		args = append(args, *arguments)
+	}
+
+	if r.hasIdentity() && i != nil {
+		idt := payload{*i}
+		identity, err := idt.parse(reflect.TypeOf(r.function).In(1))
+
+		if err != nil {
+			return nil, err
+		}
+		args = append(args, *identity)
 	}
 
 	returnValues := reflect.ValueOf(r.function).Call(args)

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -22,8 +22,7 @@ var _ = Describe("Resolver", func() {
 		Entry("Not a function, but string", "123", "Resolver is not a function, got string"),
 
 		Entry("Parameter is string", func(args string) (interface{}, error) { return nil, nil }, "Resolver argument must be struct"),
-		Entry("Too many parameters", func(args struct{}, foo struct{}) (interface{}, error) { return nil, nil }, "Resolver must not have more than one argument, got 2"),
-
+		Entry("Too many parameters", func(args struct{}, identity struct{}, foo struct{}) (interface{}, error) { return nil, nil }, "Resolver must not have more than two argument, got 3"),
 		Entry("No return value", func() {}, "Resolver must have at least one return value"),
 		Entry("Non-error return value", func(args struct{}) interface{} { return nil }, "Last return value must be an error"),
 		Entry("Multiple non-error return values", func(args struct{}) (interface{}, interface{}) { return nil, nil }, "Last return value must be an error"),

--- a/validate.go
+++ b/validate.go
@@ -28,8 +28,8 @@ var validators = validateList{
 		return nil
 	},
 	func(h reflect.Type) error {
-		if num := h.NumIn(); num > 1 {
-			return fmt.Errorf("Resolver must not have more than one argument, got %v", num)
+		if num := h.NumIn(); num > 2 {
+			return fmt.Errorf("Resolver must not have more than two argument, got %v", num)
 		}
 
 		return nil


### PR DESCRIPTION
ready to review and merge. Tested, no breaking changes.

Examples:
```
func AccessChecking(h resolvers.Handler) resolvers.Handler {
	m := func(in resolvers.Invocation) (interface{}, error) {
		out, err := h.Serve(in)
		if err != nil {
			return errortypes.Handler(err)
		}
		j, err := json.Marshal(&in.Context.Identity)
		if err != nil {
			panic(err)
		}
                // access can validate here
		fmt.Println(string(j))
		return out, err
	}
	return resolvers.HandlerFunc(m)
}

```